### PR TITLE
Change from middle click for sub menu

### DIFF
--- a/aiclass/droneMapGUI.py
+++ b/aiclass/droneMapGUI.py
@@ -207,7 +207,7 @@ class DroneGUI:
 
         # bind the button clicks to draw out the map
         self.room_canvas.bind("<Button-1>", self.toggle_obstacle_click)
-        self.room_canvas.bind("<Button-2>", self.change_obstacle_type_click)
+        self.room_canvas.bind("<Button-3>", self.change_obstacle_type_click)
 
         # add in the obstacles (if any exist already)
         (xs, ys) = np.nonzero(self.room_map)


### PR DESCRIPTION
Documentation indicates button 2 is for the middle click, so I switched it to button 3 as the comments indicate it should be. https://effbot.org/tkinterbook/tkinter-events-and-bindings.htm